### PR TITLE
Proposition of new API for meta/store

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,11 @@ module.exports = {
  *
  * @typedef {object} Meta
  * @property {ID} id Event unique ID. {@link Log#add} set it automatically.
+ * @property {number} fix Event time fix for client.
+ * @property {number} createdAt client oriented createdAt time (id[0] + fix)
  * @property {number} added Event added sequence number.
  *                          {@link Log#add} will fill it.
+ * @property {string} userId Client unique user id.
  */
 
 /**
@@ -64,7 +67,7 @@ module.exports = {
  */
 
 /**
- * Every log store should provide two methods: add and get.
+ * Every log store should provide three methods: add, remove and get.
  *
  * See {@link MemoryStore} sources for example.
  *
@@ -103,8 +106,14 @@ module.exports = {
  * This tricky API is used, because store could have a lot of events. So we need
  * pagination to keep them in memory.
  *
- * @param {"created"|"added"} order Sort events by created time
- *                                  or when they was added to current log.
+ * @param {"created"|"added"} [options.order="added"] Sort events by created
+ *                                                    time or by sequence
+ *                                                    number for current log.
+ * @param {"DESC"|"ASC"} [options.direction="DESC"] Sorting direction
+ * @param {number} [options.limit=100] Limit for entries in page
+ * @param {array} [options.createdRange=[]] Pair of from-to time.
+ *                                          Gets events in createdAt range
+ * @param {array} [options.userIds=[]] Selects events for specified users
  *
  * @return {Promise} Promise with first {@link Page}.
  *


### PR DESCRIPTION
This is first thoughts about changes in `meta` of event and store API. Here are no real implementation yet as we need to discuss that I'm in the right direction.

Also here are no `synced` and `otherSynced` as there are couple details in possible realization I need to discuss:
1. Do we want to persist value of `synced` in Store? If yes – should client/server call special method to store this value in DB or it should be performed automatically after every successful `add` call? (if yes – it is overhead - 2x requests to DB).
2. I see from logic in logux-sync that `synced` is the same as `lastAdded` in log – do we still need it if we have `synced` in our log store?
3. Should we rename `synced` and `otherSynced` to improve readability to `lastReceived`/`lastSent` or other names?