### PR TITLE
Log#add: ensure reasons to be array of strings

### DIFF
--- a/log.js
+++ b/log.js
@@ -134,7 +134,7 @@ Log.prototype = {
 
     meta.reasons.forEach(function (reason) {
       if (typeof reason !== 'string') {
-        throw new Error('Expected "reasons" to contain string values')
+        throw new Error('Expected "reasons" to be strings')
       }
     })
 

--- a/log.js
+++ b/log.js
@@ -132,11 +132,9 @@ Log.prototype = {
       meta.reasons = [meta.reasons]
     }
 
-    meta.reasons = meta.reasons.map(function (reason) {
+    meta.reasons.forEach(function (reason) {
       if (typeof reason !== 'string') {
         throw new Error('Expected "reasons" to contain string values')
-      } else {
-        return reason
       }
     })
 

--- a/log.js
+++ b/log.js
@@ -126,13 +126,19 @@ Log.prototype = {
 
     if (typeof meta.time === 'undefined') meta.time = meta.id[0]
 
-    if (meta.reasons == null) {
+    if (typeof meta.reasons === 'undefined') {
       meta.reasons = []
-    } else if (Array.isArray(meta.reasons)) {
-      meta.reasons = meta.reasons.map(String)
-    } else {
-      meta.reasons = [String(meta.reasons)]
+    } else if (!Array.isArray(meta.reasons)) {
+      meta.reasons = [meta.reasons]
     }
+
+    meta.reasons = meta.reasons.map(function (reason) {
+      if (typeof reason !== 'string') {
+        throw new Error('Expected "reasons" to contain string values')
+      } else {
+        return reason
+      }
+    })
 
     if (meta.keepLast) meta.reasons.push(meta.keepLast)
 

--- a/log.js
+++ b/log.js
@@ -125,7 +125,14 @@ Log.prototype = {
     }
 
     if (typeof meta.time === 'undefined') meta.time = meta.id[0]
-    if (typeof meta.reasons === 'undefined') meta.reasons = []
+
+    if (meta.reasons == null) {
+      meta.reasons = []
+    } else if (Array.isArray(meta.reasons)) {
+      meta.reasons = meta.reasons.map(String)
+    } else {
+      meta.reasons = [String(meta.reasons)]
+    }
 
     if (meta.keepLast) meta.reasons.push(meta.keepLast)
 

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -476,3 +476,20 @@ it('removes reasons when keepLast option is used', function () {
     return checkActions(log, [{ type: '3' }])
   })
 })
+
+it('ensures `reasons` to be array of string values', function () {
+  var log = createLog()
+
+  return log.add({ type: '1' }).then(function (meta) {
+    expect(meta.reasons).toEqual([])
+    return log.add({ type: '2' }, { reasons: null })
+  }).then(function (meta) {
+    expect(meta.reasons).toEqual([])
+    return log.add({ type: '3' }, { reasons: 'a' })
+  }).then(function (meta) {
+    expect(meta.reasons).toEqual(['a'])
+    return log.add({ type: '4' }, { reasons: [null, false, 1, { foo: 'bar' }] })
+  }).then(function (meta) {
+    expect(meta.reasons).toEqual(['null', 'false', '1', '[object Object]'])
+  })
+})

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -482,14 +482,11 @@ it('ensures `reasons` to be array of string values', function () {
 
   return log.add({ type: '1' }).then(function (meta) {
     expect(meta.reasons).toEqual([])
-    return log.add({ type: '2' }, { reasons: null })
-  }).then(function (meta) {
-    expect(meta.reasons).toEqual([])
-    return log.add({ type: '3' }, { reasons: 'a' })
+    return log.add({ type: '2' }, { reasons: 'a' })
   }).then(function (meta) {
     expect(meta.reasons).toEqual(['a'])
-    return log.add({ type: '4' }, { reasons: [null, false, 1, { foo: 'bar' }] })
-  }).then(function (meta) {
-    expect(meta.reasons).toEqual(['null', 'false', '1', '[object Object]'])
+    return log.add({ type: '3' }, { reasons: [false, 1] })
+  }).catch(function (err) {
+    expect(err.message).toEqual('Expected "reasons" to contain string values')
   })
 })

--- a/test/log.test.js
+++ b/test/log.test.js
@@ -487,6 +487,6 @@ it('ensures `reasons` to be array of string values', function () {
     expect(meta.reasons).toEqual(['a'])
     return log.add({ type: '3' }, { reasons: [false, 1] })
   }).catch(function (err) {
-    expect(err.message).toEqual('Expected "reasons" to contain string values')
+    expect(err.message).toEqual('Expected "reasons" to be strings')
   })
 })


### PR DESCRIPTION
Currently, adding an action with `reasons` set to something other than array prevents `Log#removeReason` from working properly, as `MemoryStore#removeReason` expects `meta.reasons` to be an array. This PR ensures whatever data passed as `reasons` to be converted to an array.
