### PR TITLE
Adding purge method to the inmemory store

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ Think about this store as a basic store realization.
 
 ### Custom Store
 
-Any object implementing this 5 methods can be considered a Store:
+Any object implementing this methods can be considered a Store:
 
 * `add(entry)` puts new log entry in the store. Returns a Promise with new
   action meta or `false` if action with same `id` was already in log.
@@ -555,3 +555,4 @@ Any object implementing this 5 methods can be considered a Store:
   received/sent actions.
 * `setLastSynced(values)` saves `added` values for latest synchronized
   received/sent actions and return Promise when they will be saved to store.
+* `clean()` (optional) returns Promise when store is cleaned from all the data.

--- a/each-store-check.js
+++ b/each-store-check.js
@@ -457,6 +457,28 @@ function eachStoreCheck (test) {
       })
     }
   })
+
+  test('cleans whole store if implemented', function (factory) {
+    return function () {
+      var store = factory()
+      var result = Promise.resolve()
+      if (typeof store.clean === 'function') {
+        result = Promise.all([
+          store.add({ type: 'A' }, { id: '1', time: 1 }),
+          store.add({ type: 'B' }, { id: '2', time: 2 }),
+          store.add({ type: 'C' }, { id: '3', time: 3 }),
+          store.add({ type: 'D' }, { id: '4', time: 4 }),
+          store.add({ type: 'E' }, { id: '5', time: 5 })
+        ]).then(function () {
+          return store.clean()
+        }).then(function () {
+          return checkBoth(store, [])
+        })
+      }
+
+      return result
+    }
+  })
 }
 
 module.exports = eachStoreCheck

--- a/each-store-check.js
+++ b/each-store-check.js
@@ -29,11 +29,11 @@ function checkLastAdded (store, expected) {
   })
 }
 
-function checkLastSynced (store, expectedRecieved, expectedSent) {
+function checkLastSynced (store, expectedSent, expectedRecieved) {
   return store.getLastSynced().then(function (lastSynced) {
     assert.deepEqual(lastSynced, {
-      received: expectedRecieved,
-      sent: expectedSent
+      sent: expectedSent,
+      received: expectedRecieved
     })
   })
 }
@@ -58,14 +58,10 @@ function eachStoreCheck (test) {
   test('is empty in the beginning', function (factory) {
     return function () {
       var store = factory()
-      return checkBoth(store, []).then(function () {
-        return store.getLastAdded()
-      }).then(function (added) {
-        assert.equal(added, 0)
-        return store.getLastSynced()
-      }).then(function (synced) {
-        assert.deepEqual(synced, { sent: 0, received: 0 })
-      })
+      return Promise.all([
+        checkLastAdded(store, 0),
+        checkLastSynced(store, 0, 0)
+      ])
     }
   })
 
@@ -73,15 +69,11 @@ function eachStoreCheck (test) {
     return function () {
       var store = factory()
       return store.setLastSynced({ sent: 1 }).then(function () {
-        return store.getLastSynced()
-      }).then(function (synced) {
-        return assert.deepEqual(synced, { sent: 1, received: 0 })
+        return checkLastSynced(store, 1, 0)
       }).then(function () {
         return store.setLastSynced({ received: 1 })
       }).then(function () {
-        return store.getLastSynced()
-      }).then(function (synced) {
-        return assert.deepEqual(synced, { sent: 1, received: 1 })
+        return checkLastSynced(store, 1, 1)
       })
     }
   })
@@ -90,9 +82,7 @@ function eachStoreCheck (test) {
     return function () {
       var store = factory()
       return store.setLastSynced({ sent: 2, received: 1 }).then(function () {
-        return store.getLastSynced()
-      }).then(function (synced) {
-        return assert.deepEqual(synced, { sent: 2, received: 1 })
+        return checkLastSynced(store, 2, 1)
       })
     }
   })
@@ -133,9 +123,7 @@ function eachStoreCheck (test) {
           assert.ok(added)
           return store.add({ type: 'A' }, { id: '1 n 0' })
         }).then(function () {
-          return store.getLastAdded()
-        }).then(function (added) {
-          assert.equal(added, 1)
+          return checkLastAdded(store, 1)
         })
       })
     }

--- a/each-store-check.js
+++ b/each-store-check.js
@@ -23,6 +23,21 @@ function checkBoth (store, entries) {
   ])
 }
 
+function checkLastAdded (store, expected) {
+  return store.getLastAdded().then(function (lastAdded) {
+    assert.equal(lastAdded, expected)
+  })
+}
+
+function checkLastSynced (store, expectedRecieved, expectedSent) {
+  return store.getLastSynced().then(function (lastSynced) {
+    assert.deepEqual(lastSynced, {
+      received: expectedRecieved,
+      sent: expectedSent
+    })
+  })
+}
+
 function nope () { }
 
 /**
@@ -472,7 +487,11 @@ function eachStoreCheck (test) {
         ]).then(function () {
           return store.clean()
         }).then(function () {
-          return checkBoth(store, [])
+          return Promise.all([
+            checkBoth(store, []),
+            checkLastAdded(store, 0),
+            checkLastSynced(store, 0, 0)
+          ])
         })
       }
 

--- a/index.js
+++ b/index.js
@@ -184,6 +184,15 @@ module.exports = {
  * @memberof Store#
  */
 /**
+ * Cleans the store from all the data.
+ *
+ * @return {Promise} Promise when cleaning will be finished.
+ *
+ * @name clean
+ * @function
+ * @memberof Store#
+ */
+/**
  * Return biggest `added` number in store.
  * All actions in this log have less or same `added` time.
  *

--- a/memory-store.js
+++ b/memory-store.js
@@ -180,7 +180,7 @@ MemoryStore.prototype = {
     return Promise.resolve()
   },
 
-  purge: function purge() {
+  clean: function clean () {
     this.created = []
     this.added = []
     this.lastReceived = 0

--- a/memory-store.js
+++ b/memory-store.js
@@ -180,6 +180,15 @@ MemoryStore.prototype = {
     return Promise.resolve()
   },
 
+  purge: function purge() {
+    this.created = []
+    this.added = []
+    this.lastReceived = 0
+    this.lastAdded = 0
+    this.lastSent = 0
+    return Promise.resolve()
+  },
+
   getLastAdded: function getLastAdded () {
     return Promise.resolve(this.lastAdded)
   },


### PR DESCRIPTION
Hi. I just saw an issue and would like to help with it: GH-13

There is not so much information about it, so I will just ask questions here:
1) As I understand you prefer to test store implementation through log tests. Should we have a possibility to reset the log, so then it will be possible to test store through it. Or should I write a test for memory-store that will check it?
2) Wdyt, is it okay that I just unlink data from the store and pray for GC or I should iterate with 'delete' operator overall data?